### PR TITLE
Add MustExportToFlagSet(); adjust API of ExportToFlagSet; change flagset behavior

### DIFF
--- a/flags_import.go
+++ b/flags_import.go
@@ -293,6 +293,7 @@ func ExportToFlagSet(fs FlagSet, tagName string, model interface{}, opts ...Flag
 			// default.  Using one of them would provide a default when instead, nil is
 			// appropriate.
 			fs.Func(ref.Name[0], help, func(s string) error {
+				v := getV()
 				err := setter(v, s)
 				return commonerrors.UsageError(errors.Wrap(err, s))
 			})
@@ -367,6 +368,7 @@ func ExportToFlagSet(fs FlagSet, tagName string, model interface{}, opts ...Flag
 			fs.Uint64Var(v.Addr().Interface().(*uint64), ref.Name[0], defaultInt, help)
 		default:
 			fs.Func(ref.Name[0], help, func(s string) error {
+				v := getV()
 				err := setter(v, s)
 				return commonerrors.UsageError(errors.Wrap(err, s))
 			})

--- a/flags_import.go
+++ b/flags_import.go
@@ -149,7 +149,7 @@ func ExportToFlagSet(fs FlagSet, tagName string, model interface{}, opts ...Flag
 		v := nonPtr.FieldByIndex(f.Index)
 		tagSet := reflectutils.SplitTag(f.Tag).Set()
 		tag := tagSet.Get(tagName)
-		defaultValue := tagSet.Get(defaultTag)
+		defaultValue, hasDefault := tagSet.Lookup(defaultTag)
 		ref, setterType, nonPointerType, err := parseFlagRef(tag, f.Type)
 		if err != nil {
 			return err
@@ -167,7 +167,9 @@ func ExportToFlagSet(fs FlagSet, tagName string, model interface{}, opts ...Flag
 			return vcopy
 		}
 		vt := v.Type()
+		var isPointer bool
 		for vt.Kind() == reflect.Ptr {
+			isPointer = true
 			current := getV
 			getV = func() reflect.Value {
 				v := current()
@@ -192,17 +194,6 @@ func ExportToFlagSet(fs FlagSet, tagName string, model interface{}, opts ...Flag
 		switch {
 		case len(ref.Name) == 0:
 			return commonerrors.LibraryError(errors.New("missing name"))
-		case ref.isBool:
-			v := getV()
-			var defaultBool bool
-			if defaultValue.Value != "" {
-				var err error
-				defaultBool, err = strconv.ParseBool(defaultValue.Value)
-				if err != nil {
-					return commonerrors.ProgrammerError(errors.Wrapf(err, "Parse value of %s tag for default bool", defaultTag))
-				}
-			}
-			fs.BoolVar(v.Addr().Interface().(*bool), ref.Name[0], defaultBool, help)
 		case ref.isMap:
 			ks, err := reflectutils.MakeStringSetter(nonPointerType.Key())
 			if err != nil {
@@ -296,6 +287,26 @@ func ExportToFlagSet(fs FlagSet, tagName string, model interface{}, opts ...Flag
 				return commonerrors.LibraryError(errors.Errorf("internal error: not expecting %s", v.Type()))
 			}
 
+		case isPointer && !hasDefault:
+			// For pointers without defaults, there is no point in using one of the flagset
+			// specific type functions since those require a default and we don't have a
+			// default.  Using one of them would provide a default when instead, nil is
+			// appropriate.
+			fs.Func(ref.Name[0], help, func(s string) error {
+				err := setter(v, s)
+				return commonerrors.UsageError(errors.Wrap(err, s))
+			})
+		case ref.isBool:
+			v := getV()
+			var defaultBool bool
+			if defaultValue.Value != "" {
+				var err error
+				defaultBool, err = strconv.ParseBool(defaultValue.Value)
+				if err != nil {
+					return commonerrors.ProgrammerError(errors.Wrapf(err, "Parse value of %s tag for default bool", defaultTag))
+				}
+			}
+			fs.BoolVar(v.Addr().Interface().(*bool), ref.Name[0], defaultBool, help)
 		case setterType == durationType:
 			v := getV()
 			var defaultDuration time.Duration
@@ -356,7 +367,6 @@ func ExportToFlagSet(fs FlagSet, tagName string, model interface{}, opts ...Flag
 			fs.Uint64Var(v.Addr().Interface().(*uint64), ref.Name[0], defaultInt, help)
 		default:
 			fs.Func(ref.Name[0], help, func(s string) error {
-				debug("DSLJDSL:FJSD:LFJSD:LFJSD:LFJSDL:JFDSLJFSD:J:", s)
 				err := setter(v, s)
 				return commonerrors.UsageError(errors.Wrap(err, s))
 			})
@@ -369,6 +379,14 @@ func ExportToFlagSet(fs FlagSet, tagName string, model interface{}, opts ...Flag
 	}
 
 	return nil
+}
+
+// MustExportToFlagSet wraps ExportToFlagSet with a panic if the export fails
+func MustExportToFlagSet(fs FlagSet, tagName string, model interface{}, opts ...FlaghandlerOptArg) {
+	err := ExportToFlagSet(fs, tagName, model, opts...)
+	if err != nil {
+		panic(err)
+	}
 }
 
 var durationType = reflect.TypeOf(time.Duration(0))

--- a/flags_import.go
+++ b/flags_import.go
@@ -18,6 +18,22 @@ type hasIsBool interface {
 	IsBoolFlag() bool
 }
 
+// FlagSet is a subset of what flag.FlagSet supports, defined as
+// an interface to lesson the dependency on flag.
+type FlagSet interface {
+	BoolVar(*bool, string, bool, string)
+	StringVar(*string, string, string, string)
+	DurationVar(*time.Duration, string, time.Duration, string)
+	IntVar(*int, string, int, string)
+	Int64Var(*int64, string, int64, string)
+	UintVar(*uint, string, uint, string)
+	Uint64Var(*uint64, string, uint64, string)
+	Float64Var(*float64, string, float64, string)
+	Func(string, string, func(string) error)
+	Parsed() bool
+	VisitAll(func(*flag.Flag))
+}
+
 // ImportFlagSet pulls in flags defined with the standard "flag"
 // package.  This is useful when there are libaries being used
 // that define flags.
@@ -26,7 +42,7 @@ type hasIsBool interface {
 //
 // ImportFlagSet is not the recommended way to use nfigure, but sometimes
 // there is no choice.
-func ImportFlagSet(fs *flag.FlagSet) FlaghandlerOptArg {
+func ImportFlagSet(fs FlagSet) FlaghandlerOptArg {
 	return func(h *FlagHandler) error {
 		if fs.Parsed() {
 			return commonerrors.ProgrammerError(errors.New("Cannot import FlagSets that have been parsed"))
@@ -106,7 +122,7 @@ func (h *FlagHandler) importFlags() error {
 // will be treated as numerical types.
 //
 // If a flag has multiple aliases, only the first name will be used.
-func ExportToFlagSet(fs *flag.FlagSet, tagName string, model interface{}, opts ...FlaghandlerOptArg) error {
+func ExportToFlagSet(fs FlagSet, tagName string, model interface{}, opts ...FlaghandlerOptArg) error {
 	h := GoFlagHandler(opts...)
 	err := h.PreWalk(tagName, model)
 	if err != nil {

--- a/flags_test.go
+++ b/flags_test.go
@@ -57,6 +57,8 @@ type flagSet6 struct {
 	UI64 uint64        `flag:"ui64flag" default:"40" ui64bad:"forty"`
 	D    time.Duration `flag:"dflag" default:"30m10s" dbad:"thirty min"`
 	C    complex64     `flag:"cflag"`
+	BP   *bool         `flag:"bp"`
+	CP   *complex128   `flag:"cp"`
 }
 
 type importBool struct {
@@ -137,8 +139,10 @@ var cases = []flagTestCase{
 			UI64: 41,
 			B:    false,
 			C:    289 + 8i,
+			BP:   pointer.ToBool(false),
+			CP:   pointer.ToComplex128(6 + 7i),
 		},
-		exportCmd: "-sflag abc -dflag 10m -iflag 11 -i64flag 21 -uiflag 31 -ui64flag 41 -bflag=false -cflag 289+8i",
+		exportCmd: "-sflag abc -dflag 10m -iflag 11 -i64flag 21 -uiflag 31 -ui64flag 41 -bflag=false -cflag 289+8i --bp=false --cp=6+7i",
 	},
 	{
 		base:          &flagSet6{},


### PR DESCRIPTION
This change is almost backwards compatible.

- API change: `ExportToFlagSet()` now takes an interface which means that isn't quite a locked to `"flag"` as it had been.
- `MustExportToFlagSet()` has been added.
- Behavior change: When filling a pointer member that does not have a default, if the flag isn't mentioned, the value will remain `nil` rather than being filled with the base value for the type
- The README has been updated.
- bugfix for exported flags for pointers to types not covered by the FlagSet API: this now works