### PR TITLE
Fix readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,5 @@ all:
 
 golanglint:
 	# binary will be $(go env GOPATH)/bin/golangci-lint
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.45.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.48.0
 	golangci-lint --version

--- a/README.md
+++ b/README.md
@@ -39,16 +39,17 @@ type myLibraryConfig struct {
 	Field3	[]string  `flag:"field3"`
 }
 
-type MyLibrary btruct {
+type MyLibrary struct {
 	config	myLibraryConfig
 }
 
 func createMyLibrary(nreg *nfigure.Registry) *MyLibrary {
 	lib := MyLibrary{}
-	nreg.Register(&lib.config,
+	nreg.Request(&lib.config,
 		nfigure.Prefix("myLibrary"),
 		nfigure.ConfigFileFrom(`env="MYLIBRARY_CONFIG_FILE" flag:"mylibrary-config"`),
 	)
+	_ = nreg.Configure()
 	return &lib
 }
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ type programLevelConfig struct {
 func createMyApp(myLibrary *mylibrary.MyLibrary, nreg *nfigure.Registery) error {
 	// start servers, do not return until time to shut down
 	var config programLevelConfig
-	nreg.Register(&config, "main")
+	nreg.Request(&config, "main")
 	_ = nreg.Configure()
 }
 


### PR DESCRIPTION
Fixing README.md and updating golangci-lint version. I am updating `golangci-lint` version since I am using the same `GOPATH` for another project (`xop-go`) which brings dependencies that are using generics.

cc: @muir 