### PR TITLE
[fix] re-enable lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
           # args: --out-format checkstyle
-	  args: --go=1.20
+          args: --go=1.20
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true


### PR DESCRIPTION
golangci-lint was accidentally disabled. Fix.