### PR TITLE
[feat] WithArgs

### DIFF
--- a/flags_command.go
+++ b/flags_command.go
@@ -17,8 +17,10 @@ import (
 )
 
 // These are used for testing only
-var testMode bool
-var testOutput string
+var (
+	testMode   bool
+	testOutput string
+)
 
 // General calling order....
 //
@@ -108,6 +110,7 @@ type FlagHandler struct {
 	defaultTag         string
 	debugLogger        fullLogger
 	noPositional       bool
+	args               []string
 }
 
 var (
@@ -225,6 +228,7 @@ func GoFlagHandler(opts ...FlaghandlerOptArg) *FlagHandler {
 }
 
 func (h *FlagHandler) init() {
+	h.args = os.Args
 	h.subcommands = make(map[string]*FlagHandler)
 	h.longFlags = make(map[string]*flagRef)
 	h.shortFlags = make(map[string]*flagRef)
@@ -332,6 +336,15 @@ func OnActivate(chain ...interface{}) FlaghandlerOptArg {
 			nject.Provide("default-error", func() nject.TerminalError {
 				return nil
 			})).Append("on-activate", chain...).Bind(&h.onActivate, nil)
+	}
+}
+
+// WithArgs overrides where the args to parse comes from. Without WithArgs,
+// os.Args[1:] is used. There is no current override for os.Args[0].
+func WithArgs(osArgs []string) FlaghandlerOptArg {
+	return func(h *FlagHandler) error {
+		h.args = append([]string{h.args[0]}, osArgs...)
+		return nil
 	}
 }
 
@@ -771,7 +784,7 @@ func (h *FlagHandler) Usage() string {
 	}
 
 	usage := make([]string, 0, len(h.rawData)*2+10+len(h.subcommands)*2)
-	usage = append(usage, "Usage: "+os.Args[0])
+	usage = append(usage, "Usage: "+h.args[0])
 
 	switch len(optional[flagOpt]) {
 	case 0:

--- a/flags_parse.go
+++ b/flags_parse.go
@@ -35,8 +35,8 @@ func (h *FlagHandler) ignoredFlagTakesArgument(flagName string) bool {
 // skipNextArgumentIfNotFlag skips the next argument if it doesn't look like a flag
 // This is used when we ignore a flag that might have an argument following it
 func (h *FlagHandler) skipNextArgumentIfNotFlag(currentIndex int, flagName string) int {
-	if h.ignoredFlagTakesArgument(flagName) && currentIndex+1 < len(os.Args) && !strings.HasPrefix(os.Args[currentIndex+1], "-") {
-		h.debugf("at %d, skipping argument %s for ignored flag %s", currentIndex+1, os.Args[currentIndex+1], flagName)
+	if h.ignoredFlagTakesArgument(flagName) && currentIndex+1 < len(h.args) && !strings.HasPrefix(h.args[currentIndex+1], "-") {
+		h.debugf("at %d, skipping argument %s for ignored flag %s", currentIndex+1, h.args[currentIndex+1], flagName)
 		return currentIndex + 1 // skip the next argument
 	}
 	return currentIndex
@@ -76,11 +76,11 @@ func (h *FlagHandler) parseFlags(i int) error {
 			ref.values = append(ref.values, "")
 			ref.used = append(ref.used, withDash)
 		case ref.isMap:
-			if i+1 >= len(os.Args) {
+			if i+1 >= len(h.args) {
 				return commonerrors.UsageError(errors.Errorf("Expecting a positional argument after %s, none is available", inErr))
 			}
 			i++
-			kv := strings.SplitN(os.Args[i], ref.Split, 2)
+			kv := strings.SplitN(h.args[i], ref.Split, 2)
 			if len(kv) != 2 {
 				return commonerrors.UsageError(errors.Errorf("Expecting key%svalue after %s but didn't find '%s'", ref.Split, inErr, ref.Split))
 			}
@@ -93,12 +93,12 @@ func (h *FlagHandler) parseFlags(i int) error {
 			if ref.explode != 0 {
 				count = ref.explode
 			}
-			if i+count >= len(os.Args) {
+			if i+count >= len(h.args) {
 				return commonerrors.UsageError(errors.Errorf("Expecting %d positional arguments after %s, but only %d are available",
-					count, inErr, len(os.Args)-i-1))
+					count, inErr, len(h.args)-i-1))
 			}
 			i++
-			ref.values = append(ref.values, os.Args[i:i+count]...)
+			ref.values = append(ref.values, h.args[i:i+count]...)
 			ref.used = append(ref.used, repeatString(withDash, count)...)
 			i += count - 1
 		}
@@ -163,11 +163,11 @@ func (h *FlagHandler) parseFlags(i int) error {
 		return false, commonerrors.UsageError(errors.Errorf("Flag %s%s not defined", dash, noDash))
 	}
 
-	for ; i < len(os.Args); i++ {
-		f := os.Args[i]
+	for ; i < len(h.args); i++ {
+		f := h.args[i]
 		if f == "--" {
-			remainder = os.Args[i+1:]
-			h.debugf("found -- remaining flags (%d/%d) are positional", i, len(os.Args))
+			remainder = h.args[i+1:]
+			h.debugf("found -- remaining flags (%d/%d) are positional", i, len(h.args))
 			if len(remainder) > 0 && h.noPositional {
 				return commonerrors.UsageError(errors.Errorf("flags parsing completed, with --, leaving %d unexpected positional arguments: %v",
 					len(remainder), remainder))
@@ -243,9 +243,10 @@ func (h *FlagHandler) parseFlags(i int) error {
 					return err
 				}
 			}
+			sub.args = h.args
 			return sub.parseFlags(i + 1)
 		}
-		remainder = os.Args[i:]
+		remainder = h.args[i:]
 		h.debugf("at %d, remainder is %v", i, remainder)
 		if len(remainder) > 0 && h.noPositional {
 			return commonerrors.UsageError(errors.Errorf("flags parsing completed leaving %d unexpected positional arguments: %v",
@@ -266,7 +267,7 @@ func (h *FlagHandler) parseFlags(i int) error {
 	return nil
 }
 
-// Remaining returns the arguments that were not consumed from os.Args. The other way
+// Remaining returns the arguments that were not consumed from arguments (os.Args or WithArgs()). The other way
 // to get the remaining arguments is to add an OnStart callback.
 func (h *FlagHandler) Remaining() []string {
 	return h.remainder

--- a/flags_test.go
+++ b/flags_test.go
@@ -309,7 +309,7 @@ var cases = []flagTestCase{
 		},
 		sub: "foo",
 		wantSub: &flagSet1{
-			I: 11,
+			I: 10,
 		},
 		remaining: []string{"xy"},
 	},
@@ -440,10 +440,7 @@ var cases = []flagTestCase{
 		subcommands: map[string]interface{}{
 			"foo": &flagSet1{},
 		},
-		sub: "foo",
-		wantSub: &flagSet1{
-			I: 11,
-		},
+		sub:       "foo",
 		remaining: []string{"xy"},
 		capture: deindent(`
 			Usage: PROGRAME-NAME [-options args] [parameters]
@@ -557,9 +554,21 @@ func TestFlags(t *testing.T) {
 }
 
 func flagTest(t *testing.T, tc flagTestCase) {
+	t.Run("osArgs", func(t *testing.T) {
+		os.Args = append([]string{os.Args[0]}, strings.Split(tc.cmd, " ")...)
+		doFlagTest(t, tc, nil)
+	})
+	t.Run("explicitArgs", func(t *testing.T) {
+		os.Args = []string{os.Args[0], "JUNK", "SHOULD", "NOT", "BE", "USED"}
+		doFlagTest(t, tc, []FlaghandlerOptArg{
+			WithArgs(strings.Split(tc.cmd, " ")),
+		})
+	})
+}
+
+func doFlagTest(t *testing.T, tc flagTestCase, extra []FlaghandlerOptArg) {
 	t.Log(tc.cmd)
 	var called int
-	os.Args = append([]string{os.Args[0]}, strings.Split(tc.cmd, " ")...)
 	args := []FlaghandlerOptArg{
 		OnStart(func(args []string) {
 			if tc.sub == "" {
@@ -571,6 +580,7 @@ func flagTest(t *testing.T, tc flagTestCase) {
 		}),
 	}
 	args = append(args, tc.additionalArgs...)
+	args = append(args, extra...)
 	bools := make([]*bool, len(tc.importBools))
 	if tc.importBools != nil {
 		fs := flag.NewFlagSet("importedBools", flag.ContinueOnError)
@@ -589,9 +599,12 @@ func flagTest(t *testing.T, tc flagTestCase) {
 	}
 	fh := PosixFlagHandler(args...)
 	subcalled := make(map[string]int)
+	subModels := make(map[string]interface{})
 	for sub, model := range tc.subcommands {
 		sub, model := sub, model
-		_, err := fh.AddSubcommand(sub, "help for "+sub, model, OnStart(func(args []string) {
+		subCopy := deepcopy.Copy(model)
+		subModels[sub] = subCopy
+		_, err := fh.AddSubcommand(sub, "help for "+sub, subCopy, OnStart(func(args []string) {
 			assert.Equal(t, tc.remaining, args, "remaining args in "+sub)
 			subcalled[sub]++
 		}))
@@ -638,6 +651,9 @@ func flagTest(t *testing.T, tc flagTestCase) {
 			assert.Equal(t, map[string]int{}, subcalled, "sub called")
 		} else {
 			assert.Equal(t, map[string]int{tc.sub: 1}, subcalled, "sub called")
+			if tc.wantSub != nil {
+				assert.Equal(t, tc.wantSub, subModels[tc.sub], "subcommand data")
+			}
 		}
 		for i, spec := range tc.importBools {
 			assert.Equal(t, spec.want, *bools[i], "bool "+spec.name)


### PR DESCRIPTION
Adds the `WithArgs` option to override where command line arguments come from so that they don't have to come from `os.Args`.